### PR TITLE
Fix: Creating user address after registration

### DIFF
--- a/app/Http/Controllers/Api/v1/Users/AddressController.php
+++ b/app/Http/Controllers/Api/v1/Users/AddressController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Api\v1\Users;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\v1\Users\BillingAddressRequest;
 use App\Http\Requests\v1\Users\ShippingAddressRequest;
-use App\Models\User;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -35,7 +34,7 @@ class AddressController extends Controller
         try {
             $user = auth('sanctum')->user();
 
-            $user->address()->updateOrCreate([
+            $user->address->update([
                 'billing_first_name' => $request->billing_first_name,
                 'billing_last_name' => $request->billing_last_name,
                 'billing_email' => $request->billing_email,
@@ -83,7 +82,7 @@ class AddressController extends Controller
         try {
             $user = auth('sanctum')->user();
 
-            $user->address()->updateOrCreate([
+            $user->address->update([
                 'shipping_first_name' => $request->shipping_first_name,
                 'shipping_last_name' => $request->shipping_last_name,
                 'shipping_email' => $request->shipping_email,

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+
+class UserObserver
+{
+    /**
+     * Handle events after all transactions are committed.
+     *
+     * @var bool
+     */
+    public $afterCommit = true;
+
+    /**
+     * Handle the User "created" event.
+     */
+    public function created(User $user)
+    {
+        $user->address()->create();
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -25,7 +27,7 @@ class EventServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        User::observe(UserObserver::class);
     }
 
     /**

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -41,6 +41,17 @@ class RegistrationTest extends TestCase
         $this->assertEquals($data['message'], __('response.auth.register'));
     }
 
+    public function test_user_address_gets_created_after_registration()
+    {
+        $this->withoutExceptionHandling();
+
+        $payload = $this->preparePayload();
+
+        $this->postJsonPayload($this->postRoute, $payload);
+
+        $this->assertNotNull(User::with('address')->find(2)->address);
+    }
+
     public function test_first_name_field_is_required()
     {
         $payload = $this->preparePayload(['first_name' => '']);

--- a/tests/Feature/Users/Addresses/BillingAddressTest.php
+++ b/tests/Feature/Users/Addresses/BillingAddressTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Users\Addresses;
 
-use App\Models\UserAddress;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use Tests\TestCase;
@@ -20,12 +19,10 @@ class BillingAddressTest extends TestCase
         parent::setUp();
 
         // Create the administrator for the application
-        $this->createUser();
+        $this->createUser(['is_admin' => true]);
 
         // Create a non-admin user and log in them
         $this->user = $this->signInUser();
-
-        UserAddress::factory()->create(['user_id' => $this->user->id]);
 
         $this->putRoute = route('v1_user.addresses.billing');
     }

--- a/tests/Feature/Users/Addresses/ShippingAddressTest.php
+++ b/tests/Feature/Users/Addresses/ShippingAddressTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Users\Addresses;
 
-use App\Models\UserAddress;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use Tests\TestCase;
@@ -20,12 +19,10 @@ class ShippingAddressTest extends TestCase
         parent::setUp();
 
         // Create the administrator for the application
-        $this->createUser();
+        $this->createUser(['is_admin' => true]);
 
         // Create a non-admin user and log in them
         $this->user = $this->signInUser();
-
-        UserAddress::factory()->create(['user_id' => $this->user->id]);
 
         $this->putRoute = route('v1_user.addresses.shipping');
     }


### PR DESCRIPTION
This PR fixes the issue #33 

Whenever a user registers, their address record also gets created immediately after their registration.