### PR TITLE
Redirect to documentation page

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,4 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::redirect('/', '/docs');


### PR DESCRIPTION
This PR fixes the issue #58 
By default, the user will be redirected to the `/docs` page