### PR TITLE
PHP in the list of example lanaguages

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -269,6 +269,7 @@ INTRO,
     'example_languages' => [
         'bash',
         'javascript',
+        'php',
     ],
 
     /*


### PR DESCRIPTION
This PR adds the `PHP` language to the list of example languages.