### PR TITLE
Generating docs after deployment

### DIFF
--- a/sample-envoy.blade.php
+++ b/sample-envoy.blade.php
@@ -25,5 +25,7 @@
     php artisan route:cache
     php artisan view:cache
 
+    php artisan scribe:generate
+
     echo "Check https://domain-name"
 @endtask


### PR DESCRIPTION
This PR fixes the issue #68 
The `scribe:generate` command has been added to the `Envoy` script.